### PR TITLE
Use Synchronous File Copying in         fs.writeFileSync(destinationF…

### DIFF
--- a/build/createMissingPrintChartsFromMetadata.js
+++ b/build/createMissingPrintChartsFromMetadata.js
@@ -43,7 +43,7 @@ function copyFileIfNotExists(sourceFilePath, destinationFilePath){
     if (err) {
       if (err.code === 'ENOENT') {
         console.error(destinationFilePath + ' does not exist, copying ' + sourceFilePath + '...');
-        fs.writeFile(destinationFilePath, eol.auto(fs.readFileSync(sourceFilePath)), (error) => {
+        fs.writeFileSync(destinationFilePath, eol.auto(fs.readFileSync(sourceFilePath)), (error) => {
           console.log('Error copying ' + sourceFilePath + ': ' + error); 
         });
         /*


### PR DESCRIPTION
see issue description
createMissingPrintChartsFromMetadata.js generated empty files when copying js-templates from mother -> child for print-indicators